### PR TITLE
Updated for Jekyll 2.5.x

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,8 @@ This plugin exports Habari posts as static files for Jekyll.
 
 ## Requirements
 
-* Habari = 0.6.x
+* Habari = 0.6.x (*version 0.4 tested against 0.9.2*)
+
 
 ## Installation
 

--- a/jekyllexport.plugin.php
+++ b/jekyllexport.plugin.php
@@ -2,7 +2,7 @@
 
 class JekyllExport extends Plugin
 {
-    const VERSION = '0.3';
+    const VERSION = '0.4';
 
     protected $export_dir = NULL;
     protected $template   = NULL;
@@ -106,19 +106,21 @@ class JekyllExport extends Plugin
                 .$post->pubdate->text_format('{Y}-{m}-{d}')
                 ."-$post->slug.markdown";
 
-            $title      = json_encode($post->title);
+            $permalink  = $post->slug;
             $published  = $post->status === Post::status('published') ? 'true' : 'false';
+            $title      = json_encode($post->title);
+            $date       = $post->pubdate->text_format('{Y}-{m}-{d}');
             $content    = trim($post->content);
 
-            $categories = array();
+            $jtags = array();
             foreach($post->tags as $tag) {
-                $categories[] = $tag->term;
+                $jtags[] = $tag->term;
             }
-            $categories = implode(', ', $categories);
+            $jtags = implode(' ', $jtags);
 
             $data = str_replace(
-                array('{title}', '{categories}', '{published}', '{content}'),
-                array($title, $categories, $published, $content),
+                array('{permalink}', '{published}', '{title}', '{date}', '{content}', '{jtags}'),
+                array($permalink, $published, $title, $date, $content, $jtags),
                 file_get_contents($this->template)
             );
 
@@ -188,4 +190,3 @@ class JekyllExport extends Plugin
 }
 
 ?>
-

--- a/jekyllexport.plugin.xml
+++ b/jekyllexport.plugin.xml
@@ -4,6 +4,6 @@
 	<license url="http://www.apache.org/licenses/LICENSE-2.0.html">Apache Software License 2.0</license>
 	<url>http://github.com/ahutchings/habari-jekyll-export</url>
 	<author url="http://www.andrewhutchings.com/">Andrew Hutchings</author>
-	<version>0.3</version>
+	<version>0.4</version>
 	<description>Exports Habari posts as static files for Jekyll.</description>
 </pluggable>

--- a/template.example.php
+++ b/template.example.php
@@ -1,7 +1,11 @@
 ---
-title: {title}
-categories: [{categories}]
+layout: post
+permalink: {permalink}
 published: {published}
+title: {title}
+date: {date}
+tags: {jtags}
+
 ---
 
 {content}


### PR DESCRIPTION
Added support for permalink, date and use tags in front matter instead of categories.

Also added layout: post to template example.
